### PR TITLE
Jump to replay time & Improvement backward/forward

### DIFF
--- a/src/me/jumper251/replay/replaysystem/recording/RecordingListener.java
+++ b/src/me/jumper251/replay/replaysystem/recording/RecordingListener.java
@@ -337,7 +337,7 @@ public class RecordingListener extends AbstractListener {
 
 			// Change PlayerItemInHand when fill bucket
 			ItemStack stack;
-			if (e.getBlockClicked().getState().getType().equals(Material.LAVA)) {
+			if (e.getBlockClicked().getState().getType().getId() == 10 || e.getBlockClicked().getState().getType().getId() == 11) {
 				stack = new ItemStack(Material.LAVA_BUCKET, 1);
 			} else {
 				stack = new ItemStack(Material.WATER_BUCKET, 1);


### PR DESCRIPTION
I added an api function to jump to a specific time in seconds when replaying a replay.

I also improved following things on backward/forward replaying.

Backward: In the current version when click the backward item and the replay time is under 10 Seconds, replay just stops.
My update sets replay time to 1 Tick when current replay time is under 10 seconds.

Forward: In the current version when click the forward item and the remaining replay time is under 10 Seconds, replay just stops.
My update sets replay time to 1 Second before end of replay when remaining replay time is under 10 seconds.

Like in the other pull request before, fell free to change something if you don't like it.