### PR TITLE
Add netherite armor support

### DIFF
--- a/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
+++ b/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
@@ -1,7 +1,7 @@
 package me.jumper251.replay.replaysystem.utils;
 
 import java.util.ArrayList;
-
+import java.util.Map;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -188,7 +188,18 @@ public class NPCManager {
 	
 	public static boolean isArmor(ItemStack stack) {
 		if (stack == null) return false;
-		return ARMOR.contains(stack.getType());
+		return ARMOR.contains(stack.getType()) || checkNetherite(stack);
+	}
+
+	public static boolean checkNetherite(ItemStack stack) {
+		try {
+			Map<String, Object> yaml = stack.serialize();
+			String material = (String) yaml.get("type");
+			return material.equals("NETHERITE_HELMET") || material.equals("NETHERITE_CHESTPLATE") || material.equals("NETHERITE_LEGGINGS") || material.equals("NETHERITE_BOOTS");
+		} catch (Exception exception) {
+			// Unsure what could happen on older/newer versions
+			return false;
+		}
 	}
 	
 	public static String getArmorType(ItemStack stack) {

--- a/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
+++ b/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
@@ -1,7 +1,6 @@
 package me.jumper251.replay.replaysystem.utils;
 
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
+++ b/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
@@ -193,8 +193,7 @@ public class NPCManager {
 
 	public static boolean isNetheriteArmor(ItemStack stack) {
 		try {
-			Map<String, Object> yaml = stack.serialize();
-			String material = (String) yaml.get("type");
+			String material = (String) stack.serialize().get("type");
 			return material.equals("NETHERITE_HELMET") || material.equals("NETHERITE_CHESTPLATE") || material.equals("NETHERITE_LEGGINGS") || material.equals("NETHERITE_BOOTS");
 		} catch (Exception exception) {
 			// Unsure what could happen on older/newer versions

--- a/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
+++ b/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
@@ -200,13 +200,17 @@ public class NPCManager {
 		}
 	}
 	
+	public static String getMaterialName(ItemStack stack) {
+		return (String) stack.serialize().get("type");
+	}
+
 	public static String getArmorType(ItemStack stack) {
 		if (stack == null) return null;
 		
-		if (stack.getType().toString().contains("HELMET")) return "head";
-		if (stack.getType().toString().contains("CHESTPLATE")) return "chest";
-		if (stack.getType().toString().contains("LEGGINGS")) return "leg";
-		if (stack.getType().toString().contains("BOOTS")) return "boots";
+		if (getMaterialName(stack).contains("HELMET")) return "head";
+		if (getMaterialName(stack).contains("CHESTPLATE")) return "chest";
+		if (getMaterialName(stack).contains("LEGGINGS")) return "leg";
+		if (getMaterialName(stack).contains("BOOTS")) return "boots";
 		
 		return null;
 

--- a/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
+++ b/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
@@ -188,10 +188,10 @@ public class NPCManager {
 	
 	public static boolean isArmor(ItemStack stack) {
 		if (stack == null) return false;
-		return ARMOR.contains(stack.getType()) || checkNetherite(stack);
+		return ARMOR.contains(stack.getType()) || isNetheriteArmor(stack);
 	}
 
-	public static boolean checkNetherite(ItemStack stack) {
+	public static boolean isNetheriteArmor(ItemStack stack) {
 		try {
 			Map<String, Object> yaml = stack.serialize();
 			String material = (String) yaml.get("type");

--- a/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
+++ b/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
@@ -192,13 +192,8 @@ public class NPCManager {
 
 	public static boolean isNetheriteArmor(ItemStack stack) {
 		if(VersionUtil.isAbove(VersionEnum.V1_16)) {
-			try {
-				String material = (String) stack.serialize().get("type");
-				return material.equals("NETHERITE_HELMET") || material.equals("NETHERITE_CHESTPLATE") || material.equals("NETHERITE_LEGGINGS") || material.equals("NETHERITE_BOOTS");
-			} catch (Exception exception) {
-				// Unsure what could happen on older/newer versions
-				return false;
-			}
+			String material = getMaterialName(stack);
+			return material.equals("NETHERITE_HELMET") || material.equals("NETHERITE_CHESTPLATE") || material.equals("NETHERITE_LEGGINGS") || material.equals("NETHERITE_BOOTS");
 		} else {
 			return false;
 		}

--- a/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
+++ b/src/me/jumper251/replay/replaysystem/utils/NPCManager.java
@@ -191,11 +191,15 @@ public class NPCManager {
 	}
 
 	public static boolean isNetheriteArmor(ItemStack stack) {
-		try {
-			String material = (String) stack.serialize().get("type");
-			return material.equals("NETHERITE_HELMET") || material.equals("NETHERITE_CHESTPLATE") || material.equals("NETHERITE_LEGGINGS") || material.equals("NETHERITE_BOOTS");
-		} catch (Exception exception) {
-			// Unsure what could happen on older/newer versions
+		if(VersionUtil.isAbove(VersionEnum.V1_16)) {
+			try {
+				String material = (String) stack.serialize().get("type");
+				return material.equals("NETHERITE_HELMET") || material.equals("NETHERITE_CHESTPLATE") || material.equals("NETHERITE_LEGGINGS") || material.equals("NETHERITE_BOOTS");
+			} catch (Exception exception) {
+				// Unsure what could happen on older/newer versions
+				return false;
+			}
+		} else {
 			return false;
 		}
 	}


### PR DESCRIPTION
All new items in 1.13+ are LEGACY_AIR (unless you set api-version: 1.13, which will break everything), but I've found a workaround with serialization that allows us to get the real material name. I'm not sure Spigot won't change the serialization format and .serialize().get("type") will work in future versions, so try and catch.