### PR TITLE
Chat recording changes

### DIFF
--- a/src/com/comphenix/packetwrapper/WrapperPlayServerChat.java
+++ b/src/com/comphenix/packetwrapper/WrapperPlayServerChat.java
@@ -1,0 +1,104 @@
+/**
+ * PacketWrapper - ProtocolLib wrappers for Minecraft packets
+ * Copyright (C) dmulloy2 <http://dmulloy2.net>
+ * Copyright (C) Kristian S. Strangeland
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.comphenix.packetwrapper;
+
+import java.util.Arrays;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.wrappers.EnumWrappers;
+import com.comphenix.protocol.wrappers.EnumWrappers.ChatType;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
+
+public class WrapperPlayServerChat extends AbstractPacket {
+    public static final PacketType TYPE = PacketType.Play.Server.CHAT;
+
+    public WrapperPlayServerChat() {
+        super(new PacketContainer(TYPE), TYPE);
+        handle.getModifier().writeDefaults();
+    }
+
+    public WrapperPlayServerChat(PacketContainer packet) {
+        super(packet, TYPE);
+    }
+
+    /**
+     * Retrieve the chat message.
+     * <p>
+     * Limited to 32767 bytes
+     *
+     * @return The current message
+     */
+    public WrappedChatComponent getMessage() {
+        return handle.getChatComponents().read(0);
+    }
+
+    /**
+     * Set the message.
+     *
+     * @param value - new value.
+     */
+    public void setMessage(WrappedChatComponent value) {
+        handle.getChatComponents().write(0, value);
+    }
+
+    public ChatType getChatType() {
+        return handle.getChatTypes().read(0);
+    }
+
+    public void setChatType(ChatType type) {
+        handle.getChatTypes().write(0, type);
+    }
+
+    /**
+     * Retrieve Position.
+     * <p>
+     * Notes: 0 - Chat (chat box) ,1 - System Message (chat box), 2 - Above
+     * action bar
+     *
+     * @return The current Position
+     * @deprecated Magic values replaced by enum
+     */
+    @Deprecated
+    public byte getPosition() {
+        Byte position = handle.getBytes().readSafely(0);
+        if (position != null) {
+            return position;
+        } else {
+            return getChatType().getId();
+        }
+    }
+
+    /**
+     * Set Position.
+     *
+     * @param value - new value.
+     * @deprecated Magic values replaced by enum
+     */
+    @Deprecated
+    public void setPosition(byte value) {
+        handle.getBytes().writeSafely(0, value);
+
+        if (EnumWrappers.getChatTypeClass() != null)
+        {
+            Arrays.stream(ChatType.values()).filter(t -> t.getId() == value).findAny()
+                    .ifPresent(t -> handle.getChatTypes().writeSafely(0, t));
+        }
+    }
+}

--- a/src/me/jumper251/replay/filesystem/ConfigManager.java
+++ b/src/me/jumper251/replay/filesystem/ConfigManager.java
@@ -32,8 +32,6 @@ public class ConfigManager {
 	
 	public static ReplayQuality QUALITY = ReplayQuality.HIGH;
 	
-	public static String DEATH_MESSAGE, LEAVE_MESSAGE, CHAT_FORMAT, JOIN_MESSAGE;
-	
 	public static void loadConfigs() {
 		if(!sqlFile.exists()){
 			sqlCfg.set("host", "localhost");
@@ -59,17 +57,12 @@ public class ConfigManager {
 			cfg.set("general.hide_players", false);
 			cfg.set("general.add_new_players", false);	
 			cfg.set("general.update_notifications", true);
-			
-			cfg.set("general.death_message", "&6{name} &7died.");
-			cfg.set("general.quit_message", "&6{name} &7left the game.");
-			cfg.set("general.join_message", "&6{name} &7joined the game.");
 
 			cfg.set("recording.blocks.enabled", true);
 			cfg.set("recording.blocks.real_changes", true);
 			cfg.set("recording.entities.enabled", false);
 			cfg.set("recording.entities.items.enabled", true);
 			cfg.set("recording.chat.enabled", false);
-			cfg.set("recording.chat.format", "&r<{name}> {message}");
 
 
 			try {
@@ -95,11 +88,6 @@ public class ConfigManager {
 		ADD_PLAYERS = cfg.getBoolean("general.add_new_players");
 		UPDATE_NOTIFY = cfg.getBoolean("general.update_notifications");
 		if (initial ) USE_DATABASE = cfg.getBoolean("general.use_mysql");
-
-		DEATH_MESSAGE = cfg.getString("general.death_message");
-		LEAVE_MESSAGE = cfg.getString("general.quit_message");
-		JOIN_MESSAGE = cfg.getString("general.join_message");
-		CHAT_FORMAT = cfg.getString("recording.chat.format");
 
 		RECORD_BLOCKS = cfg.getBoolean("recording.blocks.enabled");
 		REAL_CHANGES = cfg.getBoolean("recording.blocks.real_changes");

--- a/src/me/jumper251/replay/filesystem/ConfigManager.java
+++ b/src/me/jumper251/replay/filesystem/ConfigManager.java
@@ -27,7 +27,7 @@ public class ConfigManager {
 	
 	public static boolean RECORD_BLOCKS, REAL_CHANGES;
 	public static boolean RECORD_ITEMS, RECORD_ENTITIES;
-	public static boolean RECORD_CHAT;
+	public static boolean RECORD_CHAT, RECORD_EVERYTHING_IN_CHAT;
 	public static boolean SAVE_STOP, USE_OFFLINE_SKINS, HIDE_PLAYERS, UPDATE_NOTIFY, USE_DATABASE, ADD_PLAYERS;
 	
 	public static ReplayQuality QUALITY = ReplayQuality.HIGH;
@@ -63,6 +63,7 @@ public class ConfigManager {
 			cfg.set("recording.entities.enabled", false);
 			cfg.set("recording.entities.items.enabled", true);
 			cfg.set("recording.chat.enabled", false);
+			cfg.set("recording.chat.everything", false);
 
 
 			try {
@@ -94,6 +95,7 @@ public class ConfigManager {
 		RECORD_ITEMS = cfg.getBoolean("recording.entities.items.enabled");
 		RECORD_ENTITIES = cfg.getBoolean("recording.entities.enabled");
 		RECORD_CHAT = cfg.getBoolean("recording.chat.enabled");
+		RECORD_EVERYTHING_IN_CHAT = cfg.getBoolean("recording.chat.everything");
 
 		if (USE_DATABASE) {
 			

--- a/src/me/jumper251/replay/replaysystem/recording/Recorder.java
+++ b/src/me/jumper251/replay/replaysystem/recording/Recorder.java
@@ -90,7 +90,6 @@ public class Recorder {
 						if (packetData instanceof BlockChangeData && !ConfigManager.RECORD_BLOCKS) continue;
 						if (packetData instanceof EntityItemData && !ConfigManager.RECORD_ITEMS) continue;
 						if ((packetData instanceof EntityData || packetData instanceof EntityMovingData || packetData instanceof EntityAnimationData) && !ConfigManager.RECORD_ENTITIES) continue;
-						if (packetData instanceof ChatData && !ConfigManager.RECORD_CHAT) continue;
 
 
 						ActionData actionData = new ActionData(currentTick, ActionType.PACKET, name, packetData);

--- a/src/me/jumper251/replay/replaysystem/recording/RecordingListener.java
+++ b/src/me/jumper251/replay/replaysystem/recording/RecordingListener.java
@@ -182,12 +182,11 @@ public class RecordingListener extends AbstractListener {
 		}
 	}
 
-	@EventHandler
+	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onChat(AsyncPlayerChatEvent e) {
 		Player p = e.getPlayer();
 		if (recorder.getPlayers().contains(p.getName())) {
-
-			this.packetRecorder.addData(p.getName(), new ChatData(e.getMessage()));
+			this.packetRecorder.addData(p.getName(), new ChatData(String.format(e.getFormat(), e.getPlayer().getDisplayName(), e.getMessage())));
 		}
 
 	}
@@ -221,17 +220,18 @@ public class RecordingListener extends AbstractListener {
 			this.recorder.getPlayers().remove(p.getName());
 			
 			if (!this.replayLeft.contains(p.getName())) this.replayLeft.add(p.getName());
+			this.recorder.addData(this.recorder.getCurrentTick(), new ActionData(this.recorder.getCurrentTick(), ActionType.MESSAGE, p.getName(), new ChatData(e.getQuitMessage())));
 		}
 	}
 	
-	@EventHandler
+	@EventHandler (priority = EventPriority.MONITOR)
 	public void onJoin(PlayerJoinEvent e) {
 		Player p = e.getPlayer();
 		if (!this.recorder.getPlayers().contains(p.getName()) && (this.replayLeft.contains(p.getName())) || ConfigManager.ADD_PLAYERS) {
 			this.recorder.getPlayers().add(p.getName());
 			this.recorder.getData().getWatchers().put(p.getName(), new PlayerWatcher(p.getName()));
 			this.recorder.createSpawnAction(p, p.getLocation(), false);
-			this.recorder.addData(this.recorder.getCurrentTick(), new ActionData(this.recorder.getCurrentTick(), ActionType.MESSAGE, p.getName(), new ChatData(new MessageBuilder(ConfigManager.JOIN_MESSAGE).set("name", p.getName()).build())));
+			this.recorder.addData(this.recorder.getCurrentTick(), new ActionData(this.recorder.getCurrentTick(), ActionType.MESSAGE, p.getName(), new ChatData(e.getJoinMessage())));
 		
 		}
 	}
@@ -241,6 +241,7 @@ public class RecordingListener extends AbstractListener {
 		Player p = e.getEntity();
 		if (this.recorder.getPlayers().contains(p.getName())) {
 			this.recorder.addData(this.recorder.getCurrentTick(), new ActionData(0, ActionType.DEATH, p.getName(), null));
+			this.recorder.addData(this.recorder.getCurrentTick(), new ActionData(this.recorder.getCurrentTick(), ActionType.MESSAGE, p.getName(), new ChatData(e.getDeathMessage())));
 		}
 	}
 	

--- a/src/me/jumper251/replay/replaysystem/recording/RecordingListener.java
+++ b/src/me/jumper251/replay/replaysystem/recording/RecordingListener.java
@@ -185,8 +185,10 @@ public class RecordingListener extends AbstractListener {
 	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onChat(AsyncPlayerChatEvent e) {
 		Player p = e.getPlayer();
-		if (recorder.getPlayers().contains(p.getName())) {
-			this.packetRecorder.addData(p.getName(), new ChatData(String.format(e.getFormat(), e.getPlayer().getDisplayName(), e.getMessage())));
+		if(ConfigManager.RECORD_CHAT && !ConfigManager.RECORD_EVERYTHING_IN_CHAT) {
+			if (recorder.getPlayers().contains(p.getName())) {
+				this.packetRecorder.addData(p.getName(), new ChatData(String.format(e.getFormat(), e.getPlayer().getDisplayName(), e.getMessage())));
+			}
 		}
 
 	}

--- a/src/me/jumper251/replay/replaysystem/replaying/ReplayingUtils.java
+++ b/src/me/jumper251/replay/replaysystem/replaying/ReplayingUtils.java
@@ -138,11 +138,7 @@ public class ReplayingUtils {
 
 			if (action.getPacketData() instanceof ChatData) {
 				ChatData chatData = (ChatData) action.getPacketData();
-
-				replayer.sendMessage(new MessageBuilder(ConfigManager.CHAT_FORMAT)
-						.set("name", action.getName())
-						.set("message", chatData.getMessage())
-						.build());
+				replayer.sendMessage(chatData.getMessage());
 			}
 
 			if (action.getPacketData() instanceof InvData) {
@@ -330,16 +326,6 @@ public class ReplayingUtils {
 				
 				SpawnData oldSpawnData = new SpawnData(npc.getUuid(), LocationData.fromLocation(npc.getLocation()), signatures.get(action.getName()));
 				this.lastSpawnActions.addLast(new ActionData(0, ActionType.SPAWN, action.getName(), oldSpawnData));
-				
-				if (action.getType() == ActionType.DESPAWN) {
-					replayer.sendMessage(new MessageBuilder(ConfigManager.LEAVE_MESSAGE)
-							.set("name", action.getName())
-							.build());
-				} else {
-					replayer.sendMessage(new MessageBuilder(ConfigManager.DEATH_MESSAGE)
-							.set("name", action.getName())
-							.build());
-				}
 				
 			} else {
 


### PR DESCRIPTION
Resolves: #12 
- Added an option to log everything players receive in the chat (not only chat but server/plugin messages and literally everything ProtocolLib can intercept).
- Now the chat format, death messages, join/quit messages are taken from the events and not the config. Useful when you have local and global chats, or staff / supporter chats / channels / whatever