### PR TITLE
Update api-version

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,5 +1,6 @@
 name: AdvancedReplay
 version: 1.8
+api-version: 1.18
 main: me.jumper251.replay.ReplaySystem
 author: Jumper251
 depend: [ProtocolLib]


### PR DESCRIPTION
This allows the legacy message to be removed.
This does not lock it down to 1.18, this just shows what the recent jar file was build for and allows backwards compatibility with older versions may be supported as well.