### PR TITLE
Fixed select database query.

### DIFF
--- a/src/main/java/me/jumper251/replay/database/utils/AutoReconnector.java
+++ b/src/main/java/me/jumper251/replay/database/utils/AutoReconnector.java
@@ -21,7 +21,7 @@ public class AutoReconnector extends BukkitRunnable{
 	@Override
 	public void run() {
 		MySQLDatabase database = (MySQLDatabase) DatabaseRegistry.getDatabase();
-		database.update("USE "+database.getDatabase()+"");
+		database.update("USE `"+database.getDatabase()+"`");
 	}
 
 }


### PR DESCRIPTION
Fixed select database query so update method doesn't throw a excpetion due databse name containg a colon.