### PR TITLE
Add TNT tracking

### DIFF
--- a/src/main/java/me/jumper251/replay/replaysystem/data/types/EntityDestroyData.java
+++ b/src/main/java/me/jumper251/replay/replaysystem/data/types/EntityDestroyData.java
@@ -1,0 +1,15 @@
+package me.jumper251.replay.replaysystem.data.types;
+
+public class EntityDestroyData extends PacketData {
+	
+	
+	int id;
+	
+	public EntityDestroyData(int id) {
+		this.id = id;
+	}
+	
+	public int getId() {
+		return id;
+	}
+}

--- a/src/main/java/me/jumper251/replay/replaysystem/data/types/TNTSpawnData.java
+++ b/src/main/java/me/jumper251/replay/replaysystem/data/types/TNTSpawnData.java
@@ -1,0 +1,27 @@
+package me.jumper251.replay.replaysystem.data.types;
+
+public class TNTSpawnData extends PacketData {
+	
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 2309497657075148314L;
+	
+	private int id;
+	private LocationData locationData;
+	
+	
+	public TNTSpawnData(int id, LocationData locationData) {
+		this.id = id;
+		this.locationData = locationData;
+	}
+	
+	public int getId() {
+		return id;
+	}
+	
+	public LocationData getLocationData() {
+		return locationData;
+	}
+	
+}

--- a/src/main/java/me/jumper251/replay/replaysystem/recording/PacketRecorder.java
+++ b/src/main/java/me/jumper251/replay/replaysystem/recording/PacketRecorder.java
@@ -379,18 +379,10 @@ public class PacketRecorder extends AbstractListener{
 		return en.getLocation();
 	}
 
-	
-	
 	public void addData(String name, PacketData data) {
 		if (!optimizer.shouldRecord(data)) return;
-	
-		List<PacketData> list = new ArrayList<PacketData>();
-		if(this.packetData.containsKey(name)) {
-			list = this.packetData.getOrDefault(name, new ArrayList<>());
-		}
-		
-		list.add(data);
-		this.packetData.put(name, list);
+
+		this.packetData.computeIfAbsent(name, k -> new ArrayList<>()).add(data);
 	}
 	
 	public Map<String, List<PacketData>> getPacketData() {

--- a/src/main/java/me/jumper251/replay/replaysystem/recording/RecordingListener.java
+++ b/src/main/java/me/jumper251/replay/replaysystem/recording/RecordingListener.java
@@ -1,49 +1,39 @@
 package me.jumper251.replay.replaysystem.recording;
 
-import java.util.ArrayList;
-
-
-
-
-
-import java.util.List;
-import java.util.Set;
-
-
-import me.jumper251.replay.replaysystem.data.types.*;
-
-import org.bukkit.GameMode;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.block.Action;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.entity.ProjectileLaunchEvent;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.player.*;
-import org.bukkit.inventory.ItemStack;
-
 import me.jumper251.replay.filesystem.ConfigManager;
 import me.jumper251.replay.filesystem.MessageBuilder;
 import me.jumper251.replay.listener.AbstractListener;
 import me.jumper251.replay.replaysystem.data.ActionData;
 import me.jumper251.replay.replaysystem.data.ActionType;
+import me.jumper251.replay.replaysystem.data.types.*;
 import me.jumper251.replay.replaysystem.utils.ItemUtils;
 import me.jumper251.replay.replaysystem.utils.NPCManager;
 import me.jumper251.replay.utils.MaterialBridge;
+import me.jumper251.replay.utils.MathUtils;
 import me.jumper251.replay.utils.VersionUtil;
 import me.jumper251.replay.utils.VersionUtil.VersionEnum;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.*;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.*;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
 
 public class RecordingListener extends AbstractListener {
-
+	
 	
 	private PacketRecorder packetRecorder;
 	private Recorder recorder;
@@ -57,43 +47,43 @@ public class RecordingListener extends AbstractListener {
 		this.replayLeft = new ArrayList<String>();
 	}
 	
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onClick(InventoryClickEvent e) {
 		if (e.getWhoClicked() instanceof Player) {
 			Player p = (Player) e.getWhoClicked();
-    			if (recorder.getPlayers().contains(p.getName())) {
-    				this.packetRecorder.addData(p.getName(), NPCManager.copyFromPlayer(p, true, true));
-    			}
-
+			if (recorder.getPlayers().contains(p.getName())) {
+				this.packetRecorder.addData(p.getName(), NPCManager.copyFromPlayer(p, true, true));
+			}
+			
 		}
 		
 	}
 	
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onHeld(PlayerItemHeldEvent e) {
 		Player p = e.getPlayer();
 		if (recorder.getPlayers().contains(p.getName())) {
 			ItemStack stack = p.getInventory().getItem(e.getNewSlot());
 			itemInHand(p, stack);
 		}
-
+		
 		
 	}
 	
 	@SuppressWarnings("deprecation")
-	@EventHandler 
+	@EventHandler
 	public void onInteract(PlayerInteractEvent e) {
 		Player p = e.getPlayer();
 		if (recorder.getPlayers().contains(p.getName())) {
 			if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK) {
 				
 				boolean isInteractable = e.getClickedBlock() != null && ItemUtils.isInteractable(e.getClickedBlock().getType());
-				if(e.getItem() != null && ItemUtils.isUsable(e.getItem().getType()) && (!isInteractable || p.isSneaking())) {
+				if (e.getItem() != null && ItemUtils.isUsable(e.getItem().getType()) && (!isInteractable || p.isSneaking())) {
 					if (!this.recorder.getData().getWatcher(p.getName()).isBlocking()) {
 						PlayerWatcher watcher = this.recorder.getData().getWatcher(p.getName());
 						watcher.setBlocking(true);
 						this.packetRecorder.addData(p.getName(), MetadataUpdate.fromWatcher(watcher));
-					
+						
 					}
 				}
 				
@@ -107,26 +97,26 @@ public class RecordingListener extends AbstractListener {
 						if (armorType.equals("leg")) data.setLeg(NPCManager.fromItemStack(e.getItem()));
 						if (armorType.equals("boots")) data.setBoots(NPCManager.fromItemStack(e.getItem()));
 					}
-					if(e.getPlayer().getGameMode() != GameMode.CREATIVE) {
+					if (e.getPlayer().getGameMode() != GameMode.CREATIVE) {
 						data.setMainHand(null);
 					}
 					
 					this.packetRecorder.addData(p.getName(), data);
-
+					
 				}
 			}
-
+			
 			if (e.getAction() == Action.LEFT_CLICK_BLOCK && p.getTargetBlock((Set<Material>) null, 5).getType() == Material.FIRE) {
 				LocationData location = LocationData.fromLocation(p.getTargetBlock((Set<Material>) null, 5).getLocation());
-
+				
 				ItemData before = new ItemData(Material.FIRE.getId(), 0);
 				ItemData after = new ItemData(0, 0);
-
+				
 				this.packetRecorder.addData(p.getName(), new BlockChangeData(location, before, after));
 			}
-
+			
 		}
-
+		
 	}
 	
 	@SuppressWarnings("deprecation")
@@ -136,24 +126,24 @@ public class RecordingListener extends AbstractListener {
 		if (recorder.getPlayers().contains(p.getName())) {
 			if (recorder.getData().getWatcher(p.getName()).isBlocking()) {
 				PlayerWatcher watcher = this.recorder.getData().getWatcher(p.getName());
-   				watcher.setBlocking(false);
-   				this.packetRecorder.addData(p.getName(), MetadataUpdate.fromWatcher(watcher));
-   				
+				watcher.setBlocking(false);
+				this.packetRecorder.addData(p.getName(), MetadataUpdate.fromWatcher(watcher));
+				
 				InvData data = NPCManager.copyFromPlayer(p, true, true);
 				if (p.getItemInHand() != null && p.getItemInHand().getAmount() <= 1) {
 					data.setMainHand(null);
 				}
 				
 				this.packetRecorder.addData(p.getName(), data);
-
-   			}
+				
+			}
 		}
 	}
 	
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onDamage(EntityDamageEvent e) {
 		if (e.getEntity() instanceof Player) {
-			Player p = (Player)e.getEntity();
+			Player p = (Player) e.getEntity();
 			if (recorder.getPlayers().contains(p.getName())) {
 				
 				this.packetRecorder.addData(p.getName(), new AnimationData(1));
@@ -161,7 +151,7 @@ public class RecordingListener extends AbstractListener {
 				if (p.getFireTicks() > 20 && !this.recorder.getData().getWatcher(p.getName()).isBurning()) {
 					this.recorder.getData().getWatcher(p.getName()).setBurning(true);
 					this.packetRecorder.addData(p.getName(), new MetadataUpdate(true, this.recorder.getData().getWatcher(p.getName()).isBlocking(), this.recorder.getData().getWatcher(p.getName()).isElytra()));
-				} else if (p.getFireTicks() <= 20 && this.recorder.getData().getWatcher(p.getName()).isBurning()){
+				} else if (p.getFireTicks() <= 20 && this.recorder.getData().getWatcher(p.getName()).isBurning()) {
 					this.recorder.getData().getWatcher(p.getName()).setBurning(false);
 					this.packetRecorder.addData(p.getName(), new MetadataUpdate(false, this.recorder.getData().getWatcher(p.getName()).isBlocking(), this.recorder.getData().getWatcher(p.getName()).isElytra()));
 				}
@@ -177,7 +167,7 @@ public class RecordingListener extends AbstractListener {
 	}
 	
 	@SuppressWarnings("deprecation")
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onCrit(EntityDamageByEntityEvent e) {
 		if (e.getEntity() instanceof Player && e.getDamager() instanceof Player) {
 			Player damager = (Player) e.getDamager();
@@ -190,33 +180,33 @@ public class RecordingListener extends AbstractListener {
 			}
 		}
 	}
-
+	
 	@EventHandler
 	public void onChat(AsyncPlayerChatEvent e) {
 		Player p = e.getPlayer();
 		if (recorder.getPlayers().contains(p.getName())) {
-
+			
 			this.packetRecorder.addData(p.getName(), new ChatData(e.getMessage()));
 		}
-
+		
 	}
-
-
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	
+	
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onBed(PlayerBedEnterEvent e) {
 		Player p = e.getPlayer();
 		if (recorder.getPlayers().contains(p.getName())) {
-
+			
 			this.packetRecorder.addData(p.getName(), new BedEnterData(LocationData.fromLocation(e.getBed().getLocation())));
 		}
 		
 	}
 	
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onBedLeave(PlayerBedLeaveEvent e) {
 		Player p = e.getPlayer();
 		if (recorder.getPlayers().contains(p.getName())) {
-
+			
 			this.packetRecorder.addData(p.getName(), new AnimationData(2));
 		}
 		
@@ -241,7 +231,7 @@ public class RecordingListener extends AbstractListener {
 			this.recorder.getData().getWatchers().put(p.getName(), new PlayerWatcher(p.getName()));
 			this.recorder.createSpawnAction(p, p.getLocation(), false);
 			this.recorder.addData(this.recorder.getCurrentTick(), new ActionData(this.recorder.getCurrentTick(), ActionType.MESSAGE, p.getName(), new ChatData(new MessageBuilder(ConfigManager.JOIN_MESSAGE).set("name", p.getName()).build())));
-		
+			
 		}
 	}
 	
@@ -253,14 +243,14 @@ public class RecordingListener extends AbstractListener {
 		}
 	}
 	
-	@EventHandler (priority = EventPriority.MONITOR)
+	@EventHandler(priority = EventPriority.MONITOR)
 	public void onRespawn(PlayerRespawnEvent e) {
 		Player p = e.getPlayer();
 		if (this.recorder.getPlayers().contains(p.getName())) {
-
+			
 			this.recorder.createSpawnAction(p, e.getRespawnLocation(), false);
 		}
-
+		
 	}
 	
 	@SuppressWarnings("deprecation")
@@ -277,27 +267,27 @@ public class RecordingListener extends AbstractListener {
 		}
 	}
 	
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onLaunch(ProjectileLaunchEvent e) {
 		Projectile proj = e.getEntity();
 		if (proj.getShooter() instanceof Player) {
-			Player p = (Player)proj.getShooter();
+			Player p = (Player) proj.getShooter();
 			if (this.recorder.getPlayers().contains(p.getName())) {
 				LocationData spawn = LocationData.fromLocation(p.getEyeLocation());
 				LocationData velocity = LocationData.fromLocation(proj.getVelocity().toLocation(p.getWorld()));
 				
-				this.packetRecorder.addData(p.getName(),  new ProjectileData(spawn, velocity, proj.getType()));
+				this.packetRecorder.addData(p.getName(), new ProjectileData(spawn, velocity, proj.getType()));
 				this.packetRecorder.addData(p.getName(), NPCManager.copyFromPlayer(p, true, true));
 			}
 		}
 	}
-
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onPickup(PlayerPickupItemEvent e) {
 		Player p = e.getPlayer();
 		if (this.recorder.getPlayers().contains(p.getName())) {
 			// Change PlayerItemInHand
-
+			
 			if (p.getItemInHand() == null || p.getItemInHand().getType() == Material.AIR) {
 				itemInHand(p, e.getItem().getItemStack());
 			}
@@ -305,54 +295,102 @@ public class RecordingListener extends AbstractListener {
 	}
 	
 	@SuppressWarnings("deprecation")
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onPlace(BlockPlaceEvent e) {
 		Player p = e.getPlayer();
 		if (this.recorder.getPlayers().contains(p.getName())) {
 			LocationData location = LocationData.fromLocation(e.getBlockPlaced().getLocation());
-
-
+			
+			
 			ItemData before = new ItemData(e.getBlockReplacedState().getType().getId(), e.getBlockReplacedState().getData().getData());
 			ItemData after = VersionUtil.isAbove(VersionEnum.V1_13) ? new ItemData(SerializableItemStack.fromMaterial(MaterialBridge.getBlockDataMaterial(e.getBlockPlaced()))) : new ItemData(e.getBlockPlaced().getType().getId(), e.getBlockPlaced().getData());
-
+			
 			this.packetRecorder.addData(p.getName(), new BlockChangeData(location, before, after));
-
+			
 			// Change PlayerItemInHand when last block in hand
 			if (e.getItemInHand().getAmount() == 1) {
 				ItemStack stack = new ItemStack(Material.AIR, 1);
 				itemInHand(p, stack);
 			}
 		}
-
+		
 	}
 	
-	@SuppressWarnings("deprecation")
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onBreak(BlockBreakEvent e) {
 		Player p = e.getPlayer();
 		if (this.recorder.getPlayers().contains(p.getName())) {
-			LocationData location = LocationData.fromLocation(e.getBlock().getLocation());
-
-			ItemData before = VersionUtil.isAbove(VersionEnum.V1_13) ? new ItemData(SerializableItemStack.fromMaterial(MaterialBridge.getBlockDataMaterial(e.getBlock()))) : new ItemData(e.getBlock().getType().getId(), e.getBlock().getData());
-			ItemData after = new ItemData(0, 0);
-			
-			this.packetRecorder.addData(p.getName(), new BlockChangeData(location, before, after));
-
+			recordBlockBreak(p, e.getBlock());
 		}
 	}
 	
+	private final Queue<Integer> tntQueue = new LinkedList<>();
+	
+	
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+	public void onTNTExplode(EntityExplodeEvent e) {
+		if (!(e.getEntity() instanceof TNTPrimed)) return;
+		
+		TNTPrimed tnt = (TNTPrimed) e.getEntity();
+		if (!(tnt.getSource() instanceof Player)) return;
+		
+		Player p = (Player) tnt.getSource();
+		if (!this.recorder.getPlayers().contains(p.getName())) return;
+		
+		if (!tntQueue.isEmpty()) {
+			int rndID = tntQueue.poll();
+			this.packetRecorder.addData(p.getName(), new EntityDestroyData(rndID));
+		}
+		
+		for (Block block : e.blockList()) {
+			recordBlockBreak(p, block);
+			if (block.getType() == Material.TNT) {
+				
+				int rndIDNew = MathUtils.randInt(2000, 30000);
+				tntQueue.offer(rndIDNew);
+				this.packetRecorder.addData(p.getName(), new TNTSpawnData(rndIDNew, LocationData.fromLocation(block.getLocation())));
+			}
+		}
+	}
+	
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+	public void onTNTPrime(PlayerInteractEvent e) {
+		//TNTPrimeEvent is bugged without paper, so we need to use PlayerInteractEvent instead
+		Block block = e.getClickedBlock();
+		if (block == null) return;
+		if (block.getType() != Material.TNT) return;
+		if (!this.recorder.getPlayers().contains(e.getPlayer().getName())) return;
+		
+		recordBlockBreak(e.getPlayer(), block);
+		
+		Location l = block.getLocation();
+		l.add(0.5, 0, 0.5);
+		int rndID = MathUtils.randInt(2000, 30000);
+		tntQueue.offer(rndID);
+		this.packetRecorder.addData(e.getPlayer().getName(), new TNTSpawnData(rndID, LocationData.fromLocation(l)));
+	}
+	
 	@SuppressWarnings("deprecation")
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	private void recordBlockBreak(Player p, Block block) {
+		LocationData location = LocationData.fromLocation(block.getLocation());
+		ItemData before = VersionUtil.isAbove(VersionEnum.V1_13) ? new ItemData(SerializableItemStack.fromMaterial(MaterialBridge.getBlockDataMaterial(block))) : new ItemData(block.getType().getId(), block.getData());
+		ItemData after = new ItemData(0, 0);
+		
+		this.packetRecorder.addData(p.getName(), new BlockChangeData(location, before, after));
+	}
+	
+	@SuppressWarnings("deprecation")
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onFill(PlayerBucketFillEvent e) {
 		Player p = e.getPlayer();
 		if (this.recorder.getPlayers().contains(p.getName())) {
 			LocationData location = LocationData.fromLocation(e.getBlockClicked().getLocation());
-
+			
 			ItemData before = new ItemData(e.getBlockClicked().getState().getType().getId(), e.getBlockClicked().getState().getData().getData());
 			ItemData after = new ItemData(0, 0);
 			
 			this.packetRecorder.addData(p.getName(), new BlockChangeData(location, before, after));
-
+			
 			// Change PlayerItemInHand when fill bucket
 			ItemStack stack;
 			if (e.getBlockClicked().getState().getType().getId() == 10 || e.getBlockClicked().getState().getType().getId() == 11) {
@@ -365,7 +403,7 @@ public class RecordingListener extends AbstractListener {
 	}
 	
 	@SuppressWarnings("deprecation")
-	@EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
+	@EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
 	public void onEmpty(PlayerBucketEmptyEvent e) {
 		Player p = e.getPlayer();
 		if (this.recorder.getPlayers().contains(p.getName())) {
@@ -376,7 +414,7 @@ public class RecordingListener extends AbstractListener {
 			ItemData after = new ItemData(e.getBucket() == Material.LAVA_BUCKET ? 11 : 9, 0);
 			
 			this.packetRecorder.addData(p.getName(), new BlockChangeData(location, before, after));
-
+			
 			// Change PlayerItemInHand
 			ItemStack stack = new ItemStack(Material.BUCKET, 1);
 			itemInHand(p, stack);
@@ -392,15 +430,15 @@ public class RecordingListener extends AbstractListener {
 			
 			this.packetRecorder.addData(p.getName(), new WorldChangeData(location));
 		}
-
+		
 	}
-
+	
 	public void itemInHand(Player p, ItemStack stack) {
 		InvData data = NPCManager.copyFromPlayer(p, true, true);
 		data.setMainHand(NPCManager.fromItemStack(stack));
-
+		
 		this.packetRecorder.addData(p.getName(), data);
-
+		
 		if (recorder.getData().getWatcher(p.getName()).isBlocking()) {
 			recorder.getData().getWatcher(p.getName()).setBlocking(false);
 			this.packetRecorder.addData(p.getName(), new MetadataUpdate(recorder.getData().getWatcher(p.getName()).isBurning(), false, this.recorder.getData().getWatcher(p.getName()).isElytra()));


### PR DESCRIPTION
Forgive me for the formatting changes. It found the formatting is inconsistent and I've chosen the more common formatting.

This tracks igniting TNT by player, and the TNT that is triggered thereafter. It also sends a destroy packet for the TNT based on when it explodes because the fuseticks are a server side thing and the derived TNT has random fuse ticks.

I've tested this and it works pretty great. Only problem is that due to TNTPrimeEvent being bugged (in 1.8) we cannot track the TNT movement on spawn so well. Furthermore, TNT being launched by other TNT unfortunately does not show in the replay. But this is already much better than nothing.